### PR TITLE
repository 'backpack_install' does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ echo export PATH='$HOME/bin:$PATH' >> ~/.bashrc
 Install `backpack_install`:
 
 ```sh
-awesome install backpack_install
+awesome install https://github.com/shinokada/backpack_install.git
 # check the version
 backpack_install -v
 ```


### PR DESCRIPTION
After these [fixes](https://github.com/shinokada/backpack_install/issues/3#issuecomment-855388871) - it was confusing

```
$ awesome install backpack_install
fatal: repository 'backpack_install' does not exist
```
It works
```
$ awesome install https://github.com/shinokada/backpack_install.git
Cloning into 'backpack_install'...
bla-bla-bla...
```